### PR TITLE
Integrate Concierge Service with Docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Or, if you don't have gradle, then:
 ### Interactive Run
 
 ```
-docker run -it -p 9080:9080 -e LICENSE=accept gameon-room bash
+docker run -it -p 9080:9080 --env-file=dockerrc gameon-room bash
 ```
 
 Then, you can start the server with 
@@ -46,7 +46,7 @@ Then, you can start the server with
 ### Daemon Run
 
 ```
-docker run -d -p 9080:9080 -e LICENSE=accept --name gameon-room gameon-room
+docker run -d -p 9080:9080 --env-file=dockerrc --name gameon-room gameon-room
 ```
 
 ### Stop
@@ -58,7 +58,7 @@ docker stop gameon-room ; docker rm gameon-room
 ### Restart Daemon
 
 ```
-docker stop gameon-room ; docker rm gameon-room ; docker run -d -p 9080:9080 -e LICENSE=accept --name gameon-room gameon-room 
+docker stop gameon-room ; docker rm gameon-room ; docker run -d -p 9080:9080 --env-file=dockerrc --name gameon-room gameon-room 
 ```
 
 ## Docker for Concierge App

--- a/room-app/src/main/java/net/wasdev/gameon/room/BoringRoom.java
+++ b/room-app/src/main/java/net/wasdev/gameon/room/BoringRoom.java
@@ -32,7 +32,7 @@ import net.wasdev.gameon.room.common.Room;
  */
 @ApplicationScoped
 public class BoringRoom implements RoomProvider {
-	protected static final String ENV_ROOM_SVC = "service.room";
+	protected static final String ENV_ROOM_SVC = "service_room";
 	private String endPoint = null;
 	protected final Room room;
 	private ConcurrentMap<String, String> players = new ConcurrentHashMap<String, String>();	//players currently in this room

--- a/room-app/src/main/java/net/wasdev/gameon/room/LifecycleManager.java
+++ b/room-app/src/main/java/net/wasdev/gameon/room/LifecycleManager.java
@@ -37,7 +37,7 @@ import net.wasdev.gameon.room.common.Room;
  */
 @HandlesTypes(RoomProvider.class)
 public class LifecycleManager implements ServletContainerInitializer {
-	private static final String ENV_CONCIERGE_SVC = "service.concierge";
+	private static final String ENV_CONCIERGE_SVC = "service_concierge";
 	private String conciergeLocation = null;
 	
 	@Override

--- a/room-wlpcfg/Dockerfile
+++ b/room-wlpcfg/Dockerfile
@@ -3,5 +3,6 @@ FROM websphere-liberty:latest
 MAINTAINER Ben Smith
 
 ADD ./servers/gameon-room /opt/ibm/wlp/usr/servers/defaultServer/
+RUN rm /opt/ibm/wlp/usr/servers/defaultServer/bootstrap.properties
 
 CMD ["/opt/ibm/wlp/bin/server", "run", "defaultServer"]

--- a/room-wlpcfg/dockerrc.example
+++ b/room-wlpcfg/dockerrc.example
@@ -1,5 +1,3 @@
-# Where to find the remote concierge service
 service_concierge=http://localhost:9081/concierge/registerRoom
-
-# Local to this server (this is the URL we hand out)
 service_room=ws://localhost:9080/rooms
+LICENSE=accept


### PR DESCRIPTION
- Update doc to include reference to dockerrc for concierge service,
too.
- BoringRoom and LifecycleManager need to please read a property called
"service_concierge" instead of "service.concierge" so that it can be the
same name as an environment variable.
- Same goes for "service.room"
- Dockerfile now just removes the bootstrap properties file and sets
those properties via environment variables.