### PR TITLE
Update etcdpaths

### DIFF
--- a/room-wlpcfg/startup.sh
+++ b/room-wlpcfg/startup.sh
@@ -28,11 +28,11 @@ if [ "$ETCDCTL_ENDPOINT" != "" ]; then
   keytool -delete -storepass testOnlyKeystore -alias endeca -keystore security/key.jks
   keytool -v -importkeystore -srcalias 1 -alias 1 -destalias default -noprompt -srcstorepass keystore -deststorepass testOnlyKeystore -srckeypass keystore -destkeypass testOnlyKeystore -srckeystore cert.pkcs12 -srcstoretype PKCS12 -destkeystore security/key.jks -deststoretype JKS
 
-  export service_map=$(etcdctl get /map/url)
+  export service_map=$(etcdctl get /room/mapurl)
   export service_room=$(etcdctl get /room/service)
   export MAP_KEY=$(etcdctl get /passwords/map-key)
   export LOGSTASH_ENDPOINT=$(etcdctl get /logstash/endpoint)
-  export SYSTEM_ID=$(etcdctl get /player/system_id)
+  export SYSTEM_ID=$(etcdctl get /global/system_id)
   export KAFKA_URL=$(etcdctl get /kafka/url)
   export KAFKA_USER=$(etcdctl get /kafka/user)
   export KAFKA_PASSWORD=$(etcdctl get /passwords/kafka)


### PR DESCRIPTION
Data already updated in etcd.. moving paths to more sane locations
Room will no longer use the map url directly, as room needs to use the _External_ address for map, not the internal via a8 .. 
Room being the oddball service thats part of the core, but pretending not to be.
Maybe further updates to remove kafka from room now kafka is in use elsewhere.
Signed-off-by: Ozzy Osborne <ozzy@ca.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-room/76)
<!-- Reviewable:end -->
